### PR TITLE
Fix ypo in !GetAtt FindApplicationsFunction

### DIFF
--- a/sam_template/template.yaml
+++ b/sam_template/template.yaml
@@ -115,7 +115,7 @@ Outputs:
     Value: !GetAtt FlagApplicationFunction.Arn
   FindApplicationsFunctionArn:
     Description: "Find Applications Function ARN"
-    Value: !GetAtt FindApplicationFunction.Arn
+    Value: !GetAtt FindApplicationsFunction.Arn
   ApproveApplicationFunctionArn:
     Description: "Approve Application Function ARN"
     Value: !GetAtt ApproveApplicationFunction.Arn


### PR DESCRIPTION
Line 118 missing an "s" in FindApplicationsFunction.Arn.

The deploy would fail:

Initiating deployment
=====================

`Waiting for changeset to be created..
Error: Failed to create changeset for the stack: step-functions-workshop, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Template error: instance of Fn::GetAtt references undefined resource FindApplicationFunction`